### PR TITLE
*WIP* handling id's that come back as strings

### DIFF
--- a/lib/jsonrpc2/response.ex
+++ b/lib/jsonrpc2/response.ex
@@ -21,8 +21,16 @@ defmodule JSONRPC2.Response do
   Returns a tuple containing the information contained in `response`.
   """
   @spec id_and_response(map) :: {:ok, id_and_response} | {:error, any}
-  def id_and_response(%{"jsonrpc" => "2.0", "id" => id, "result" => result}) do
+  def id_and_response(%{"jsonrpc" => "2.0", "id" => id, "result" => result}) when is_integer(id) do
     {:ok, {id, {:ok, result}}}
+  end
+
+  def id_and_response(%{"jsonrpc" => "2.0", "id" => id, "result" => result} = response) when is_binary(id) do
+    try do
+      {:ok, {String.to_integer(id), {:ok, result}}}
+    rescue
+      e in ArgumentError -> {:error, {:invalid_response, response}}
+    end
   end
 
   def id_and_response(%{"jsonrpc" => "2.0", "id" => id, "error" => error}) do

--- a/test/jsonrpc2/response_test.exs
+++ b/test/jsonrpc2/response_test.exs
@@ -1,0 +1,21 @@
+defmodule JSONRPC2.Client.TCPTest do
+  use ExUnit.Case, async: true
+
+  test "id_and_response work with int" do
+    raw_response = %{"jsonrpc" => "2.0", "result" => "{'Test': 'int'}", "id"=>123}
+    assert raw_response
+      |> JSONRPC2.Response.id_and_response == {:ok, {123, {:ok, "{'Test': 'int'}"}}}
+  end
+
+  test "id_and_response work with string" do
+    raw_response = %{"jsonrpc" => "2.0", "result" => "{'Test': 'string'}", "id"=>"987"}
+    assert raw_response
+      |> JSONRPC2.Response.id_and_response == {:ok, {987, {:ok, "{'Test': 'string'}"}}}
+  end
+
+  test "id_and_response work with bad string" do
+    raw_response = %{"jsonrpc" => "2.0", "result" => "{'Test': 'bad string'}", "id"=>"Foo"}
+    assert raw_response
+      |> JSONRPC2.Response.id_and_response == {:error, {:invalid_response, raw_response}}
+  end
+end


### PR DESCRIPTION
We talked about making this configurable but I have a  question about how we configure it:

If we can toggle this functionality off and it gets a string id should it:
* Silently timeout (this can make the issue hard to debug and know you need to toggle the feature on)
* Raise an exception along the lines of: expected 123 got "123" . Try toggling string coercion on when talking to this service. 