### PR TITLE
Use keword merge instead of list concatenation

### DIFF
--- a/lib/jsonrpc2/clients/tcp.ex
+++ b/lib/jsonrpc2/clients/tcp.ex
@@ -40,7 +40,7 @@ defmodule JSONRPC2.Clients.TCP do
         host -> host
       end
 
-    client_opts = [ip: ip, port: port, socket_options: [:binary, packet: :line]] ++ client_opts
+    client_opts = Keyword.merge([ip: ip, port: port, socket_options: [:binary, packet: :line]], client_opts)
     :shackle_pool.start(name, Protocol, client_opts, pool_opts)
   end
 


### PR DESCRIPTION
Hello, 

Trying to test my application with your module, I encountered an issue, my sent back buffer was not fully received, After some debugging, I understood that it came from the gen_tcp buffer size that was too short to handle the response properly.

I've made a little modification to your code allowing to override the socket_options provided to shackle.

Thanks for your work ;)

Fred