### PR TITLE
Handling a triplet in the decoder response

### DIFF
--- a/lib/jsonrpc2/server/handler.ex
+++ b/lib/jsonrpc2/server/handler.ex
@@ -74,6 +74,9 @@ defmodule JSONRPC2.Server.Handler do
 
       {:error, _error} ->
         standard_error_response(:parse_error, nil)
+
+      {:error, :invalid, _number} ->
+        standard_error_response(:parse_error, nil)
     end
     |> encode_response(module, serializer, json)
   end


### PR DESCRIPTION
The decoder sometimes returns a triplet that is not handled by the handle function.
A way to generate the failure is to start the TCP server, open a telnet connection to it and send ^C.
The error is the following:
`
11:48:49.723 [error] Task #PID<0.487.0> started from #PID<0.480.0> terminating
** (CaseClauseError) no case clause matching: {:error, :invalid, 2}
    (jsonrpc2) lib/jsonrpc2/server/handler.ex:65: JSONRPC2.Server.Handler.handle/3
    (jsonrpc2) lib/jsonrpc2/servers/tcp/protocol.ex:29: anonymous fn/4 in JSONRPC2.Servers.TCP.Protocol.handle_info/2
    (elixir) lib/task/supervised.ex:85: Task.Supervised.do_apply/2
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Function: #Function<0.105362011/0 in JSONRPC2.Servers.TCP.Protocol.handle_info/2>
    Args: []
`