### PR TITLE
Set plug response

### DIFF
--- a/lib/jsonrpc2/servers/http/plug.ex
+++ b/lib/jsonrpc2/servers/http/plug.ex
@@ -36,5 +36,6 @@ defmodule JSONRPC2.Servers.HTTP.Plug do
 
   def call(conn, _) do
     conn
+    |> Plug.Conn.resp(404, "")
   end
 end


### PR DESCRIPTION
Another bug.

For methods other than post Cowboy fails because jsonrpc2 does not sets the response on the connection.