### PR TITLE
Adds handling of one more potential error response from server or deserializer

### DIFF
--- a/lib/jsonrpc2/response.ex
+++ b/lib/jsonrpc2/response.ex
@@ -14,6 +14,7 @@ defmodule JSONRPC2.Response do
     case serializer.decode(response) do
       {:ok, response} -> id_and_response(response)
       {:error, error} -> {:error, error}
+      {:error, error, _} -> {:error, error}
     end
   end
 


### PR DESCRIPTION
Handles the following error response:
`** (CaseClauseError) no case clause matching: {:error, :invalid, 0}
    (jsonrpc2) lib/jsonrpc2/response.ex:14: JSONRPC2.Response.deserialize_response/2
    (jsonrpc2) lib/jsonrpc2/clients/http.ex:26: JSONRPC2.Clients.HTTP.call/6`