### PR TITLE
Language Server Protocol Serializer

### DIFF
--- a/lib/jsonrpc2.ex
+++ b/lib/jsonrpc2.ex
@@ -1,6 +1,6 @@
 defmodule JSONRPC2 do
   @moduledoc ~S"""
-  `JSONRPC2` is an Elixir library for JSON-RPC 2.0.
+  `JSONRPC2` is an Elixir library for JSON-RPC 2.0.
 
   It includes request and response utility modules, a transport-agnostic server handler, a
   line-based TCP server and client, which are based on [Ranch](https://github.com/ninenines/ranch)

--- a/lib/jsonrpc2/serializers/lsp.ex
+++ b/lib/jsonrpc2/serializers/lsp.ex
@@ -1,0 +1,76 @@
+defmodule JSONRPC2.Serializers.SerializeError do
+  @moduledoc false
+  @type t :: %__MODULE__{pos: integer, value: String.t}
+
+  defexception pos: nil, value: nil
+
+  def message(%{value: nil, pos: pos}) do
+    "Unexpected end of input at position #{pos}"
+  end
+
+  def message(%{value: value, pos: pos}) do
+    start = pos - String.length(value)
+    "Cannot parse value at position #{start}: #{inspect(value)}"
+  end
+
+end
+
+defmodule JSONRPC2.Serializers.LSP do
+  @moduledoc """
+  The Language Server Protocol (LSP) serializer can be used to encode and decode
+  messages sent per the Languagse Server Protocol specification. For further info, See:
+  https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#base-protocol
+  """
+
+  alias JSONRPC2.Serializers.SerializeError
+
+  def decode(packet) do
+    try do
+      {:ok, read_packet!(packet)}
+    catch
+      kind, payload -> {:error, {kind, payload}}
+    end
+  end
+
+  def encode(packet) do
+    try do
+      body = Poison.encode!(packet) <> "\r\n\r\n"
+      {:ok, "Content-Length: #{byte_size(body)}\r\n\r\n" <> body}
+    catch
+      kind, payload -> {:error, {kind, payload}}
+    end
+  end
+
+  defp read_packet!(packet, headers \\ %{})
+  defp read_packet!("", _headers), do: ""
+  defp read_packet!(packet, headers)
+  when is_bitstring(packet) do
+    read_packet!(String.split(packet, "\r\n"), headers)
+  end
+  defp read_packet!(packet, headers)
+  when is_list(packet) do
+    case packet do
+      ["", body, "", ""] ->
+        read_body!(body <> "\r\n\r\n", headers)
+      [header | rest] ->
+        [key, value] = String.split(header, ": ")
+        read_packet!(rest, Map.put(headers, key, value))
+      _ ->
+        ""
+    end
+  end
+
+  defp read_body!(body, headers) do
+    %{"Content-Length" => content_length_str} = headers
+    content_length = String.to_integer(content_length_str)
+    body_length = byte_size(body)
+    case (body_length - content_length) do
+      length when length < 0 ->
+        raise %SerializeError{pos: body_length}
+      length when length > 0 ->
+        raise %SerializeError{pos: content_length, value: body}
+      _ ->
+        Poison.decode!(body)
+    end
+  end
+end

--- a/test/jsonrpc2/lsp_test.exs
+++ b/test/jsonrpc2/lsp_test.exs
@@ -1,0 +1,61 @@
+defmodule JSONRPC2.LSPTest do
+  use ExUnit.Case, async: true
+  alias JSONRPC2.Clients.TCP, as: TCPClient
+  alias JSONRPC2.Serializers.LSP
+
+  setup do
+    port = :rand.uniform(65535 - 1000) + 1000
+
+    {:ok, pid} = JSONRPC2.Servers.TCP.start_listener(JSONRPC2.LSPHandler, port, name: __MODULE__)
+
+    :ok = TCPClient.start("localhost", port, __MODULE__)
+
+    on_exit fn ->
+      ref = Process.monitor(pid)
+      TCPClient.stop(__MODULE__)
+      JSONRPC2.Servers.TCP.stop(__MODULE__)
+      receive do
+        {:DOWN, ^ref, :process, ^pid, :shutdown} -> :ok
+      end
+    end
+  end
+
+  setup_all do
+    {:ok, challenges: [
+    ["alpha", "beta", "gamma"],
+    [1,2,3],
+    %{"c" => 3, "b" => 2, "x" => 1},
+    "stuff",
+    55,
+    0.253,
+    true,
+    false,
+    nil,
+    [],
+    %{},
+    %{"array" => [1,2,3],
+      "nil" => nil,
+      "string" => "sanity",
+      "number" => 12,
+      "another object" => %{
+        "array" => [],
+        "string" => "five",
+        "number" => 5,
+        "nil" => nil
+      }
+    }
+  ]}
+  end
+
+  test "it should be able to serialize and deserialize values", state do
+    Enum.each(state[:challenges], fn challenge ->
+      serialize_deserialize_test(challenge)
+    end)
+  end
+
+  defp serialize_deserialize_test(value) do
+    {:ok, encoded} = LSP.encode(value)
+    {:ok, decoded} = LSP.decode(encoded)
+    assert(value == decoded)
+  end
+end

--- a/test/support/handlers.ex
+++ b/test/support/handlers.ex
@@ -22,6 +22,20 @@ defmodule JSONRPC2.SpecHandler do
   end
 end
 
+defmodule JSONRPC2.LSPHandler do
+  use JSONRPC2.Server.Handler
+  alias JSONRPC2.Serializers.LSP
+
+  def handle_request("encode", [message]) do
+    LSP.encode(message)
+  end
+
+  def handle_request("decode", [packet]) do
+    LSP.decode(packet)
+  end
+
+end
+
 defmodule JSONRPC2.ErrorHandler do
   use JSONRPC2.Server.Handler
 


### PR DESCRIPTION
* Adds the `lsp` serializer to the project. The Language Server Protocol serializer can communicate with language server clients. For more information, see:
https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#base-protocol