### PR TITLE
Modify  judgement of `method_not_found`

### DIFF
--- a/lib/jsonrpc2/server/handler.ex
+++ b/lib/jsonrpc2/server/handler.ex
@@ -122,8 +122,12 @@ defmodule JSONRPC2.Server.Handler do
     try do
       result_response(module.handle_request(method, params), id)
     rescue
-      FunctionClauseError ->
-        standard_error_response(:method_not_found, id)
+      error in FunctionClauseError  ->
+        if error.module == module and error.function == :handle_request do
+          standard_error_response(:method_not_found, id)
+        else
+          raise error
+        end
     catch
       :throw, error when error in @throwable_errors ->
         standard_error_response(error, id)


### PR DESCRIPTION
In the original code, every `FunctionClauseError`  will cause a `method_not_found`,  this RP is tried to fix the problem. Only the  `FunctionClauseError` of  `handle_request` makes `method_not_found`. 