### PR TITLE
Plug.Adapters.Cowboy2 -> Plug.Cowboy

### DIFF
--- a/lib/jsonrpc2/servers/http.ex
+++ b/lib/jsonrpc2/servers/http.ex
@@ -83,7 +83,7 @@ defmodule JSONRPC2.Servers.HTTP do
       |> Version.parse!()
       |> Version.match?("~> 2.0")
       |> case do
-        true -> Plug.Adapters.Cowboy2
+        true -> Plug.Cowboy
         false -> Plug.Adapters.Cowboy
       end
     else

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule JSONRPC2.Mixfile do
           :shackle_pool,
           Plug.Conn,
           Plug.Adapters.Cowboy,
-          Plug.Adapters.Cowboy2
+          Plug.Cowboy
         ]
       ]
     ]


### PR DESCRIPTION
`Plug.Adapters.Cowboy2` has been deprecated in favor of using the `Plug.Cowboy` module of `:cowboy` 2.0 and above

I'm not sure if this is valid for all 2.0 and above versions of cowboy, but it seems to be from my research into both Plug and Cowboys Repo, so it shouldn't cause any backwards compatibility issues as long as people already include `:cowboy` 2.0 as a dependency