### PR TITLE
Fix params spec for JSON map with atom keys

### DIFF
--- a/lib/jsonrpc2.ex
+++ b/lib/jsonrpc2.ex
@@ -152,11 +152,10 @@ defmodule JSONRPC2 do
           | integer
           | String.t()
           | [json]
-          | %{optional(String.t()) => json}
-          | %{optional(atom()) => json}
+          | %{optional(String.t() | atom()) => json}
 
   @typedoc "A JSON-RPC 2.0 params value."
-  @type params :: [json] | %{optional(String.t()) => json} | %{optional(atom()) => json}
+  @type params :: [json] | %{optional(String.t() | atom()) => json}
 
   @typedoc "A JSON-RPC 2.0 request ID."
   @type id :: String.t() | number

--- a/lib/jsonrpc2.ex
+++ b/lib/jsonrpc2.ex
@@ -152,10 +152,10 @@ defmodule JSONRPC2 do
           | integer
           | String.t()
           | [json]
-          | %{optional(String.t() | atom()) => json}
+          | %{optional(String.t()) => json}
 
   @typedoc "A JSON-RPC 2.0 params value."
-  @type params :: [json] | %{optional(String.t() | atom()) => json}
+  @type params :: [term] | %{optional(String.t() | atom()) => term}
 
   @typedoc "A JSON-RPC 2.0 request ID."
   @type id :: String.t() | number

--- a/lib/jsonrpc2.ex
+++ b/lib/jsonrpc2.ex
@@ -153,9 +153,10 @@ defmodule JSONRPC2 do
           | String.t()
           | [json]
           | %{optional(String.t()) => json}
+          | %{optional(atom()) => json}
 
   @typedoc "A JSON-RPC 2.0 params value."
-  @type params :: [json] | %{optional(String.t()) => json}
+  @type params :: [json] | %{optional(String.t()) => json} | %{optional(atom()) => json}
 
   @typedoc "A JSON-RPC 2.0 request ID."
   @type id :: String.t() | number

--- a/test/jsonrpc2/http_test.exs
+++ b/test/jsonrpc2/http_test.exs
@@ -80,5 +80,15 @@ defmodule JSONRPC2.HTTPTest do
              ],
              :post
            ) == {:ok, 1}
+
+    assert JSONRPC2.Clients.HTTP.call(
+             "http://localhost:#{port}/",
+             "subtract",
+             %{minuend: 2, subtrahend: 1},
+             [
+               {"content-type", "application/json"}
+             ],
+             :post
+           ) == {:ok, 1}
   end
 end

--- a/test/jsonrpc2/http_test.exs
+++ b/test/jsonrpc2/http_test.exs
@@ -69,4 +69,16 @@ defmodule JSONRPC2.HTTPTest do
                :get
              )
   end
+
+  test "call application/json", %{port: port} do
+    assert JSONRPC2.Clients.HTTP.call(
+             "http://localhost:#{port}/",
+             "subtract",
+             %{"minuend" => 2, "subtrahend" => 1},
+             [
+               {"content-type", "application/json"}
+             ],
+             :post
+           ) == {:ok, 1}
+  end
 end


### PR DESCRIPTION
When using JSON atom maps, dialyzer complains that the function `JSONRPC2.Clients.HTTP.call` will not succeed, even if it will succeed. 

So, I have fixed that and added additional tests for `application/json` calls.